### PR TITLE
Add ability to customize normals provided to render_offscren_rgb

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+To develop
+---------
+
+E.g.
+```
+CONDACI_VERSION=6.6.6 conda build ./conda/ --python=2.7 && conda install ~/miniconda3/conda-bld/osx-64/cyrasterize-6.6.6-np110py27_0.tar.bz2
+```
+Make sure to kill .cpp files or Cython doesn't seem to compile...

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 To develop
 ---------
 
-E.g.
+It's easiest to do the whole build with conda as this will link the correct dependencies accross platforms:
 ```
-CONDACI_VERSION=6.6.6 conda build ./conda/ --python=2.7 && conda install ~/miniconda3/conda-bld/osx-64/cyrasterize-6.6.6-np110py27_0.tar.bz2
+CONDACI_VERSION=6.6.6 conda build ./conda/ --python=2.7
 ```
-Make sure to kill .cpp files or Cython doesn't seem to compile...
+Note that `CONDACI_VERSION` just needs to be set, can be anything whilst you develop.
+
+See the end of the build for the location of a tar.gz that you can install into an env for testing, e.g.:
+```
+conda install ~/miniconda3/conda-bld/osx-64/cyrasterize-6.6.6-np110py27_0.tar.bz2
+```
+

--- a/cyrasterize/base.py
+++ b/cyrasterize/base.py
@@ -11,13 +11,11 @@ class CyUniformBase(object):
     Parameters
     ----------
 
-    opengl : an CyRasterize canvas instance
+    opengl : A CyRasterize canvas instance
 
     Notes
     -----
     """
-
-
     def __init__(self, opengl):
         self._opengl = opengl
 
@@ -35,6 +33,14 @@ class CyUniformBase(object):
                 fget=partial(fget, name=name),
                 fset=partial(fset, name=name), doc=doc)
             )
+
+    def __str__(self):
+        s = ''
+        uniforms = self._opengl.get_active_uniforms()
+        for name in uniforms:
+            s += '{}\n'.format(name)
+            s += '{}\n\n'.format(self.__getattribute__(name))
+        return s
 
 
 class CyRasterizerBase(object):
@@ -122,7 +128,6 @@ class CyRasterizerBase(object):
     @property
     def projection_matrix(self):
         return self._opengl.get_projection_matrix()
-
 
     def set_shaders(self, geometry=None, vertex=None, fragment=None, use_last_uniforms=True):
 

--- a/cyrasterize/glrasterizer.pyx
+++ b/cyrasterize/glrasterizer.pyx
@@ -395,11 +395,14 @@ cdef class GLScene:
             np.ndarray[float, ndim=2, mode="c"] tcoords not None,
             np.ndarray[float, ndim=3, mode="c"] texture not None):
 
+        # Calculate the per-vertex normals...
         cdef np.ndarray[float, ndim=2, mode="c"] normals = vertex_normals(points, trilist)
-        print('rendering through custom normals code...')
+        # ...and then call the more flexible custom_vertex_normals code.
         return self.render_offscreen_rgb_custom_vertex_normals(
             points, normals, f3v_data, trilist, tcoords, texture)
 
+    # A more flexible version of render_offscreen_rgb where custom
+    # per-vertex normals can be provided.
     def render_offscreen_rgb_custom_vertex_normals(self,
             np.ndarray[float, ndim=2, mode="c"] points not None,
             np.ndarray[float, ndim=2, mode="c"] normals not None,


### PR DESCRIPTION
This is useful for allowing for per-triangle per-vertex interpolations (e.g. for inverse rendering applications).